### PR TITLE
Add modbus tcp to robotiq 2 finger

### DIFF
--- a/robotiq_2_finger_gripper_driver/include/robotiq_2_finger_gripper_driver/robotiq_2_finger_gripper_driver.hpp
+++ b/robotiq_2_finger_gripper_driver/include/robotiq_2_finger_gripper_driver/robotiq_2_finger_gripper_driver.hpp
@@ -252,7 +252,7 @@ public:
   }
 };
 
-class Robotiq2FingerGripperModbusRtuInterface
+class Robotiq2FingerGripperModbusInterface
 {
 protected:
 
@@ -265,13 +265,10 @@ protected:
 
 public:
 
-  Robotiq2FingerGripperModbusRtuInterface(
-      const std::function<void(const std::string&)>& logging_fn,
-      const std::string& modbus_rtu_interface,
-      const int32_t gripper_baud_rate,
-      const uint16_t gripper_slave_id);
+  Robotiq2FingerGripperModbusInterface(
+      const std::function<void(const std::string&)>& logging_fn);
 
-  ~Robotiq2FingerGripperModbusRtuInterface();
+  virtual ~Robotiq2FingerGripperModbusInterface();
 
   inline void Log(const std::string& message) { logging_fn_(message); }
 
@@ -287,9 +284,35 @@ public:
 
 protected:
 
+  void ConfigureModbusConnection(const uint16_t gripper_slave_id);
+
   bool WriteMultipleRegisters(const uint16_t start_register,
                               const std::vector<uint16_t>& register_values);
 
   void ShutdownConnection();
+};
+
+class Robotiq2FingerGripperModbusRtuInterface
+    : public Robotiq2FingerGripperModbusInterface
+{
+public:
+
+  Robotiq2FingerGripperModbusRtuInterface(
+      const std::function<void(const std::string&)>& logging_fn,
+      const std::string& modbus_rtu_interface,
+      const int32_t modbus_rtu_baud_rate,
+      const uint16_t gripper_slave_id);
+};
+
+class Robotiq2FingerGripperModbusTcpInterface
+    : public Robotiq2FingerGripperModbusInterface
+{
+public:
+
+  Robotiq2FingerGripperModbusTcpInterface(
+      const std::function<void(const std::string&)>& logging_fn,
+      const std::string& modbus_tcp_address,
+      const int32_t modbus_tcp_port,
+      const uint16_t gripper_slave_id);
 };
 }

--- a/robotiq_2_finger_gripper_driver/src/robotiq_2_finger_gripper_driver_node.cpp
+++ b/robotiq_2_finger_gripper_driver/src/robotiq_2_finger_gripper_driver_node.cpp
@@ -159,6 +159,7 @@ int main(int argc, char** argv)
   const double DEFAULT_POLL_RATE = 10.0;
   const std::string DEFAULT_STATE_TOPIC("robotiq_2_finger_state");
   const std::string DEFAULT_COMMAND_TOPIC("robotiq_2_finger_command");
+  const int32_t DEFAULT_MODBUS_TCP_PORT = 502;
   const int32_t DEFAULT_GRIPPER_BAUD_RATE = 115200;
   const int32_t DEFAULT_GRIPPER_SLAVE_ID = 0x09;
   // Start ROS
@@ -169,7 +170,7 @@ int main(int argc, char** argv)
   const std::string modbus_tcp_address
       = nhp.param(std::string("modbus_tcp_address"), std::string(""));
   const int32_t modbus_tcp_port
-      = nhp.param(std::string("modbus_tcp_port"), 0);
+      = nhp.param(std::string("modbus_tcp_port"), DEFAULT_MODBUS_TCP_PORT);
   const std::string modbus_rtu_interface
       = nhp.param(std::string("modbus_rtu_interface"), std::string(""));
   const int32_t modbus_rtu_baud_rate


### PR DESCRIPTION
Adds support for a Robotiq 2-finger gripper connected via Modbus TCP->RTU bridge.